### PR TITLE
ci: リリースを生成できなかったのをおそらく修正

### DIFF
--- a/.github/workflows/tagging.yml
+++ b/.github/workflows/tagging.yml
@@ -26,9 +26,9 @@ jobs:
     steps:
       - run: >
           gh release create '${{ github.ref_name }}'
-          --target '${{ github.ref_name }}'
           --title '${{ github.ref_name }}'
           --generate-notes
+          --verify-tag
         env: 
           GH_HOST: github.com
           GH_PROMPT_DISABLED: 1


### PR DESCRIPTION
`--target` をつけた時の挙動がイメージしていたものと違った……？

<img width="754" alt="スクリーンショット 2025-04-10 15 03 43" src="https://github.com/user-attachments/assets/57cdf67d-94c0-4d9d-8d9e-b32c0de0d0ab" />
