### PR TITLE
feat: add pnpm support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,9 @@ jobs:
           - macos-latest
           - ubuntu-latest
           - windows-latest
+        pm:
+          - npm
+          - pnpm
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 5
     permissions:
@@ -31,6 +34,10 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: lts/*
+      - if: matrix.pm == 'pnpm'
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+        with:
+          version: 10
       - id: os-info
         uses: openameba/action-os-info@b1395f434e5fc0aab838ce4f823d6c844e230f07 # v1.0.0
       - id: cache-key
@@ -38,36 +45,51 @@ jobs:
           echo 'suffix=${{ format('{0}-{1}-{2}-{3}', runner.environment, runner.arch, runner.os, steps.os-info.outputs.version) }}'
           | tee -a "$GITHUB_OUTPUT"
       - run: echo '{"private":true}' | tee package.json
-      - run: npm install --no-audit --no-progress --prefer-offline --save-exact undici
+      - if: matrix.pm == 'pnpm'
+        run: pnpm install --prefer-offline --save-exact undici
+      - if: matrix.pm == 'npm'
+        run: npm install --no-audit --no-progress --prefer-offline --save-exact undici
       - run: |
-          gh cache delete 'npm-${{ steps.cache-key.outputs.suffix }}-${{ hashFiles('package-lock.json') }}'
-          gh cache delete 'node_modules-${{ steps.cache-key.outputs.suffix }}-${{ hashFiles('package-lock.json') }}'
+          gh cache delete '${{ matrix.pm }}-${{ steps.cache-key.outputs.suffix }}-${{ hashFiles('pnpm-lock.yaml', '**/package-lock.json') }}'
+          gh cache delete 'node_modules-${{ steps.cache-key.outputs.suffix }}-${{ hashFiles('**/package-lock.json') }}'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_PROMPT_DISABLED: 1
         continue-on-error: true
       - uses: ./save
       - id: npm-cache
-        run: echo "dir=$(npm config get cache)" >> "$GITHUB_OUTPUT"
+        run: |
+          case "$PM" in
+            pnpm)
+              echo "dir=$(pnpm store path)" | tee -a "$GITHUB_OUTPUT"
+              ;;
+            npm)
+              echo "dir=$(npm config get cache)" | tee -a "$GITHUB_OUTPUT"
+              ;;
+          esac
+        env:
+          PM: ${{ matrix.pm }}
       - uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: ${{ steps.npm-cache.outputs.dir }}
-          key: npm-${{ steps.cache-key.outputs.suffix }}-${{ hashFiles('package-lock.json') }}
+          key: ${{ matrix.pm }}-${{ steps.cache-key.outputs.suffix }}-${{ hashFiles('pnpm-lock.yaml', '**/package-lock.json') }}
           fail-on-cache-miss: true
           lookup-only: true
-      - uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+      - if: matrix.pm == 'npm'
+        uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
         with:
           path: '**/node_modules'
-          key: node_modules-${{ steps.cache-key.outputs.suffix }}-${{ hashFiles('package-lock.json') }}
+          key: node_modules-${{ steps.cache-key.outputs.suffix }}-${{ hashFiles('**/package-lock.json') }}
           fail-on-cache-miss: true
           lookup-only: true
       - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          if-no-files-found: error
-          name: metafiles-${{ steps.cache-key.outputs.suffix }}
+          if-no-files-found: ignore
+          name: ${{ matrix.pm }}-metafiles-${{ steps.cache-key.outputs.suffix }}
           path: |
             package.json
             package-lock.json
+            pnpm-lock.yaml
           retention-days: 1
   restore:
     strategy:
@@ -77,6 +99,9 @@ jobs:
           - macos-latest
           - ubuntu-latest
           - windows-latest
+        pm:
+          - npm
+          - pnpm
     runs-on: ${{ matrix.runner }}
     needs: save
     timeout-minutes: 5
@@ -90,6 +115,10 @@ jobs:
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version: lts/*
+      - if: matrix.pm == 'pnpm'
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+        with:
+          version: 10
       - id: os-info
         uses: openameba/action-os-info@b1395f434e5fc0aab838ce4f823d6c844e230f07 # v1.0.0
       - id: cache-key
@@ -98,14 +127,20 @@ jobs:
           | tee -a "$GITHUB_OUTPUT"
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          name: metafiles-${{ steps.cache-key.outputs.suffix }}
+          name: ${{ matrix.pm }}-metafiles-${{ steps.cache-key.outputs.suffix }}
       - id: restore
         uses: ./restore
-      - run: test -d "$(npm config get cache)"
-      - run: test -d node_modules
+      - if: matrix.pm == 'pnpm'
+        run: test -d "$(pnpm store path)"
+      - if: matrix.pm == 'npm'
+        run: test -d "$(npm config get cache)"
+      - if: matrix.pm == 'npm'
+        run: test -d node_modules
       - run: test -n '${{ steps.restore.outputs.npm-cache-hit }}'
       - run: test -n '${{ steps.restore.outputs.npm-cache-primary-key }}'
       - run: test -n '${{ steps.restore.outputs.npm-cache-matched-key }}'
       - run: test -n '${{ steps.restore.outputs.node_modules-cache-hit }}'
-      - run: test -n '${{ steps.restore.outputs.node_modules-cache-primary-key }}'
-      - run: test -n '${{ steps.restore.outputs.node_modules-cache-matched-key }}'
+      - if: matrix.pm == 'npm'
+        run: test -n '${{ steps.restore.outputs.node_modules-cache-primary-key }}'
+      - if: matrix.pm == 'npm'
+        run: test -n '${{ steps.restore.outputs.node_modules-cache-matched-key }}'

--- a/restore/action.yml
+++ b/restore/action.yml
@@ -30,9 +30,17 @@ outputs:
 runs:
   using: composite
   steps:
-    - id: npm-cache
+    - id: detect-pm
       shell: bash
-      run: echo "dir=$(npm config get cache)" | tee -a "$GITHUB_OUTPUT"
+      run: |
+        if [ -f 'pnpm-lock.yaml' ]
+        then
+          echo 'pm=pnpm' | tee -a "$GITHUB_OUTPUT"
+          echo "dir=$(pnpm store path)" | tee -a "$GITHUB_OUTPUT"
+        else
+          echo 'pm=npm' | tee -a "$GITHUB_OUTPUT"
+          echo "dir=$(npm config get cache)" | tee -a "$GITHUB_OUTPUT"
+        fi
 
     - id: os-info
       uses: openameba/action-os-info@b1395f434e5fc0aab838ce4f823d6c844e230f07 # v1.0.0
@@ -46,24 +54,50 @@ runs:
     - id: restore-cache
       uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
-        path: ${{ steps.npm-cache.outputs.dir }}
-        key: npm-${{ steps.cache-key.outputs.suffix }}-${{ hashFiles('package-lock.json') }}
+        path: ${{ steps.detect-pm.outputs.dir }}
+        key: ${{ steps.detect-pm.outputs.pm }}-${{ steps.cache-key.outputs.suffix }}-${{ hashFiles('pnpm-lock.yaml', '**/package-lock.json') }}
         restore-keys: |
-          npm-${{ steps.cache-key.outputs.suffix }}-
-          npm-
+          ${{ steps.detect-pm.outputs.pm }}-${{ steps.cache-key.outputs.suffix }}-
+          ${{ steps.detect-pm.outputs.pm }}-
 
-    - id: restore-node_modules
+    - if: steps.detect-pm.outputs.pm == 'npm'
+      id: restore-npm-node_modules
       uses: actions/cache/restore@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: '**/node_modules'
         # NOTE: restore node_modules only when key matches exactly
-        key: node_modules-${{ steps.cache-key.outputs.suffix }}-${{ hashFiles('package-lock.json') }}
+        key: node_modules-${{ steps.cache-key.outputs.suffix }}-${{ hashFiles('**/package-lock.json') }}
 
-    - if: steps.restore-node_modules.outputs.cache-hit != 'true'
+    - id: restore-node_modules
+      shell: bash
+      run: |
+        if [ "$PM" == 'npm' ]
+        then
+          echo "cache-hit=${{ steps.restore-npm-node_modules.outputs.cache-hit }}" | tee -a "$GITHUB_OUTPUT"
+          echo "cache-primary-key=${{ steps.restore-npm-node_modules.outputs.cache-primary-key }}" | tee -a "$GITHUB_OUTPUT"
+          echo "cache-matched-key=${{ steps.restore-npm-node_modules.outputs.cache-matched-key }}" | tee -a "$GITHUB_OUTPUT"
+        else
+          echo 'cache-hit=false' | tee -a "$GITHUB_OUTPUT"
+          echo 'cache-primary-key=' | tee -a "$GITHUB_OUTPUT"
+          echo 'cache-matched-key=' | tee -a "$GITHUB_OUTPUT"
+        fi
+      env:
+        PM: ${{ steps.detect-pm.outputs.pm }}
+
+    - if: steps.detect-pm.outputs.pm == 'pnpm'
+      shell: bash
+      run: pnpm install --frozen-lockfile --ignore-scripts --prefer-offline
+      env:
+        NPM_AUTH_TOKEN: ${{ inputs.token }}
+
+    - if: steps.restore-node_modules.outputs.cache-hit != 'true' && steps.detect-pm.outputs.pm == 'npm'
       shell: bash
       run: npm ci --no-audit --ignore-scripts --prefer-offline --no-progress
       env:
         NPM_AUTH_TOKEN: ${{ inputs.token }}
 
     - shell: bash
-      run: npm rebuild && npm run prepare --if-present
+      run: >
+        "$PM" rebuild && "$PM" run --if-present prepare
+      env:
+        PM: ${{ steps.detect-pm.outputs.pm }}

--- a/save/action.yml
+++ b/save/action.yml
@@ -14,15 +14,29 @@ inputs:
 runs:
   using: composite
   steps:
-    - if: inputs.install != 'false'
+    - id: detect-pm
+      shell: bash
+      run: |
+        if [ -f 'pnpm-lock.yaml' ]
+        then
+          echo 'pm=pnpm' | tee -a "$GITHUB_OUTPUT"
+          echo "dir=$(pnpm store path)" | tee -a "$GITHUB_OUTPUT"
+        else
+          echo 'pm=npm' | tee -a "$GITHUB_OUTPUT"
+          echo "dir=$(npm config get cache)" | tee -a "$GITHUB_OUTPUT"
+        fi
+
+    - if: inputs.install != 'false' && steps.detect-pm.outputs.pm == 'pnpm'
+      shell: bash
+      run: pnpm install --frozen-lockfile --ignore-scripts --prefer-offline
+      env:
+        NPM_AUTH_TOKEN: ${{ inputs.token }}
+
+    - if: inputs.install != 'false' && steps.detect-pm.outputs.pm == 'npm'
       shell: bash
       run: npm ci --no-audit --ignore-scripts --prefer-offline --no-progress
       env:
         NPM_AUTH_TOKEN: ${{ inputs.token }}
-
-    - id: npm-cache
-      shell: bash
-      run: echo "dir=$(npm config get cache)" | tee -a "$GITHUB_OUTPUT"
 
     - id: os-info
       uses: openameba/action-os-info@b1395f434e5fc0aab838ce4f823d6c844e230f07 # v1.0.0
@@ -35,10 +49,11 @@ runs:
 
     - uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
-        path: ${{ steps.npm-cache.outputs.dir }}
-        key: npm-${{ steps.cache-key.outputs.suffix }}-${{ hashFiles('package-lock.json') }}
+        path: ${{ steps.detect-pm.outputs.dir }}
+        key: ${{ steps.detect-pm.outputs.pm }}-${{ steps.cache-key.outputs.suffix }}-${{ hashFiles('pnpm-lock.yaml', '**/package-lock.json') }}
 
-    - uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
+    - if: steps.detect-pm.outputs.pm == 'npm'
+      uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4
       with:
         path: '**/node_modules'
-        key: node_modules-${{ steps.cache-key.outputs.suffix }}-${{ hashFiles('package-lock.json') }}
+        key: node_modules-${{ steps.cache-key.outputs.suffix }}-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
- Add package manager detection (pnpm-lock.yaml)
- pnpm: use `pnpm store path` for cache directory
- pnpm: use `pnpm install --frozen-lockfile`
- npm only: restore/save node_modules cache
- Update test matrix to include both npm and pnpm

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
